### PR TITLE
Add musnix, a real-time audio NixOS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Generates a Nix expression for your Bundler-managed application.
 
 ## NixOS modules
 
+* [Musnix](https://github.com/musnix/musnix) - Real-time audio in NixOS.
 * [nixcloud-webservices](https://github.com/nixcloud/nixcloud-webservices) - focuses on ease of deployment of web-related technologies
 * [Simple Nixos Mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver) - A complete mailserver managed with NixOS modules.
 


### PR DESCRIPTION
Musnix is a real-time audio module which provides options for NixOS to make it more usable for audio tasks. I've used it for some time and will definitively use it again if I'll find time to make music again (which hopefully happens soon).
It works really well and I had never any problems with it, so I'd say it's definitively production ready.