### PR TITLE
Add comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 
 ## Command-line tools
 
+* [comma](https://github.com/Shopify/comma) - Quickly run any binary; wraps together `nix run` and `nix-index`.
 * [nix-diff](https://github.com/Gabriel439/nix-diff) - 
 Explain why two Nix derivations differ.
 * [nix-index](https://github.com/bennofs/nix-index) - 


### PR DESCRIPTION
Super useful tool and a neat combination showing the power of Nix.

> Comma runs software without installing it.
>
> Basically it just wraps together nix run and nix-index.
> You stick a , in front of a command to run it from whatever location
> it happens to occupy in nixpkgs without really thinking about it.

https://github.com/Shopify/comma