### PR TITLE
Reorganize lists alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,26 +60,26 @@ Quickly locate nix packages with specific files.
 
 ## Development
 
-* [lorri](https://github.com/target/lorri/) - A much better `nix-shell` for development.
-* [cached-nix-shell](https://github.com/xzfc/cached-nix-shell) - A `nix-shell` replacementt that uses caching to open subsequent shells quickly. 
-* [nix-review](https://github.com/Mic92/nix-review) - The best tool to verify that a pull-request in nixpkgs is building properly.
-* [niv](https://github.com/nmattia/niv/) - Easy dependency management for Nix projects.
-* [pre-commit-hooks.nix](https://github.com/hercules-ci/pre-commit-hooks.nix) - 
-Run linters/formatters at commit time and on your CI
-* [gitignore.nix](https://github.com/hercules-ci/gitignore.nix) - 
-Most feature complete and easy to use .gitignore integration
 * [arion](https://github.com/hercules-ci/arion) -
 Run docker-compose with help from Nix/NixOS 
+* [cached-nix-shell](https://github.com/xzfc/cached-nix-shell) - A `nix-shell` replacementt that uses caching to open subsequent shells quickly. 
 * [Cachix](https://cachix.org/) - Hosted binary cache service
+* [gitignore.nix](https://github.com/hercules-ci/gitignore.nix) - 
+Most feature complete and easy to use .gitignore integration
+* [lorri](https://github.com/target/lorri/) - A much better `nix-shell` for development.
+* [niv](https://github.com/nmattia/niv/) - Easy dependency management for Nix projects.
+* [nix-review](https://github.com/Mic92/nix-review) - The best tool to verify that a pull-request in nixpkgs is building properly.
+* [pre-commit-hooks.nix](https://github.com/hercules-ci/pre-commit-hooks.nix) - 
+Run linters/formatters at commit time and on your CI
 
 ## Programming languages
 
 ### Elm
 
-* [Nix Elm Tools](https://github.com/turboMaCk/nix-elm-tools) -
-Elm language community tooling for Nix and NixOS users.
 * [elm2nix](https://github.com/hercules-ci/elm2nix) - 
 Convert elm.json into Nix expressions
+* [Nix Elm Tools](https://github.com/turboMaCk/nix-elm-tools) -
+Elm language community tooling for Nix and NixOS users.
 
 ### Haskell
 
@@ -98,9 +98,9 @@ Alternative Haskell Infrastructure for Nixpkgs
 
 * [napalm](https://github.com/nmattia/napalm) -
 Support for building npm packages in Nix and lightweight npm registry.
+* [node2nix](https://github.com/svanderburg/node2nix)
 * [yarn2nix](https://github.com/moretea/yarn2nix) -
 Generate nix expressions from a yarn.lock file.
-* [node2nix](https://github.com/svanderburg/node2nix)
 
 ### PureScript
 
@@ -109,9 +109,9 @@ Generate nix expressions from a yarn.lock file.
 ### Python
 
 * [mach-nix](https://github.com/DavHau/mach-nix) - Tool to create highly reproducible python environments
+* [poetry2nix](https://github.com/nix-community/poetry2nix) - Build Python packages directly from [Poetry's](http://python-poetry.org/) poetry.lock. No conversion step needed.
 * [pypi2nix](https://github.com/nix-community/pypi2nix) - Generate Nix
   expressions for Python packages
-* [poetry2nix](https://github.com/nix-community/poetry2nix) - Build Python packages directly from [Poetry's](http://python-poetry.org/) poetry.lock. No conversion step needed.
 
 ### Ruby
 
@@ -132,14 +132,14 @@ Generates a Nix expression for your Bundler-managed application.
 
 ## Overlays
 
-* [NUR](https://github.com/nix-community/NUR/) - Nix User Repositories. The mother of all overlays.
+* [awesome-nix-hpc](https://github.com/freuk/awesome-nix-hpc) - High Performance Computing package sets
 * [home-manager](https://github.com/rycee/home-manager) - Manager user configuration just like NixOS.
+* [nix-bitcoin](https://github.com/fort-nix/nix-bitcoin) -
+Nix packages and nixos modules for Bitcoin nodes with higher layer protocols with an emphasis on security.
 * [nix-darwin](https://github.com/LnL7/nix-darwin) - Manage macOS configuration just like on NixOS.
 * [nixpkgs-mozilla](https://github.com/mozilla/nixpkgs-mozilla) - Mozilla's overlay with bleeding Rust and Firefox.
 * [nixpkgs-wayland](https://github.com/colemickens/nixpkgs-wayland) - Bleeding edge Wayland packages.
-* [nix-bitcoin](https://github.com/fort-nix/nix-bitcoin) -
-Nix packages and nixos modules for Bitcoin nodes with higher layer protocols with an emphasis on security.
-* [awesome-nix-hpc](https://github.com/freuk/awesome-nix-hpc) - High Performance Computing package sets
+* [NUR](https://github.com/nix-community/NUR/) - Nix User Repositories. The mother of all overlays.
 
 ## Community
 


### PR DESCRIPTION
Fixes #44.

Ensure lists are alphabetic. Unsure of how punctuation is considered though; usually hyphens/dashes are considered equivalent to spaces, but unsure what, say, periods would be considered in ordering, affecting where elements like `nix.dev` go in the list.