### PR TITLE
Fix GitHub action to run against main or master as target branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - master
 jobs:
   Awesome_Lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In copying the GitHub action for #1 I just took it as-is, not realizing it only runs on pull requests targeting a "main" branch.

I expanded out the YAML list and added "master" to it, so it should run against the default branch, regardless of its name.