### PR TITLE
Add missing space between item and dash on line 56 for awesome-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 ## Channel History 
 
-* [Channel History](https://channels.nix.gsc.io)- Get historical git commits for Nix channels.
+* [Channel History](https://channels.nix.gsc.io) - Get historical git commits for Nix channels.
 * [Nix Infra Status](https://status.nixos.org) - Get the age/current git commit of all Nix channels.
 
 ## Cloud Stuff


### PR DESCRIPTION
Extremely simple: add a missing space on line 56 between the dash separator and the item itself.

A very specific catch by `awesome-lint`, but an easy fix.

Part of #1 to try to get added to the Awesome list.