### PR TITLE
Fix Description on Line 138 to Start with a Capital Letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
 ## NixOS Modules
 
 * [Musnix](https://github.com/musnix/musnix) - Real-time audio in NixOS.
-* [nixcloud-webservices](https://github.com/nixcloud/nixcloud-webservices) - focuses on ease of deployment of web-related technologies.
+* [nixcloud-webservices](https://github.com/nixcloud/nixcloud-webservices) - Focuses on ease of deployment of web-related technologies.
 * [Simple Nixos Mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver) - A complete mailserver managed with NixOS modules.
 
 ## Overlays


### PR DESCRIPTION
The last of the easiest fixes for `awesome-lint`, just make sure that every description starts with a capital letter. Fixes line 138 specifically to replace `focuses` with `Focuses`.

Part of #1 to try to get added to the Awesome list.