### PR TITLE
Remove the HPC Section to Clean Up Duplicate of awesome-nix-hpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 * [Installation Media](#installation-media)
 * [Channel History](#channel-history)
 * [Cloud Stuff](#cloud-stuff)
-* [High Performance Computing](#high-performance-computing)
 * [Command-Line Tools](#command-line-tools)
 * [Development](#development)
 * [Programming Languages](#programming-languages)
@@ -66,10 +65,6 @@
 * [nixos-shell](https://github.com/Mic92/nixos-shell) - Simple headless VM configuration using Nix (similar to Vagrant).
 * [terraform-nixos](https://github.com/tweag/terraform-nixos) - A set of Terraform modules that are designed to deploy NixOS.
 * [terranix](https://terranix.org) - Use Nix and the NixOS module system to write your Terraform code.
-
-## High Performance Computing
-
-* [awesome-nix-hpc](https://github.com/freuk/awesome-nix-hpc) - Nix for High Performance Computing link collection.
 
 ## Command-Line Tools
 


### PR DESCRIPTION
The Awesome list `awesome-nix-hpc` is listed twice in the `README.md`, an issue caught by `awesome-lint`.

This PR removes the "High Performance Computing" copy and the then-emptied section.

Part of #1 to try to get added to the Awesome list.