### PR TITLE
Fix Poetry Project's Link to be HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 ### Python
 
 * [mach-nix](https://github.com/DavHau/mach-nix) - Tool to create highly reproducible python environments.
-* [poetry2nix](https://github.com/nix-community/poetry2nix) - Build Python packages directly from [Poetry's](http://python-poetry.org/) poetry.lock. No conversion step needed.
+* [poetry2nix](https://github.com/nix-community/poetry2nix) - Build Python packages directly from [Poetry's](https://python-poetry.org/) poetry.lock. No conversion step needed.
 * [pypi2nix](https://github.com/nix-community/pypi2nix) - Generate Nix expressions for Python packages.
 
 ### Ruby


### PR DESCRIPTION
The link to the Poetry website in the list is HTTP, and there exists an HTTPS version of the site, so change the protocol to HTTPS to match.

Part of #60 to do some general cleanup.