### PR TITLE
Add "Official" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ## Contents
 
+* [Official](#official)
 * [Resources](#resources)
     * [Learning](#learning)
     * [Discovery](#discovery)
@@ -28,6 +29,12 @@
 * [NixOS Modules](#nixos-modules)
 * [Overlays](#overlays)
 * [Community](#community)
+
+## Official
+
+* [Website](https://nixos.org)
+* [Documentation](https://nixos.org/learn)
+* [Package Repository](https://github.com/nixos/nixpkgs)
 
 ## Resources
 


### PR DESCRIPTION
Create a minimal "Official" Section, including only the website, official documentation, and the package repository. Also adds it to the Table of Contents.

Figured this closes #68, as most of those other resources are listed throughout the document. Plus, this is an awesome list meant to feature community projects, not an exhaustive resource list.

I'll probably make a separate pr to add NixCon into the "Community" section later.