### PR TITLE
Add nix-tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 * [nix-diff](https://github.com/Gabriel439/nix-diff) - A tool to explain why two Nix derivations differ.
 * [nix-index](https://github.com/bennofs/nix-index) - Quickly locate Nix packages with specific files.
 * [nix-prefetch](https://github.com/msteen/nix-prefetch) - A universal tool for updating source checksums.
+* [nix-tree](https://github.com/utdemir/nix-tree) - Interactively browse the dependency graph of Nix derivations.
 
 ## Development
 


### PR DESCRIPTION
`nix-tree` is a terminal tool to interactively browse dependency graphs of Nix derivations/store paths. It is especially useful to investigate the closure size of a path.

I'm the author of the tool, so this is a shameless plug; please feel free to close the issue if it is not worthy :).