### PR TITLE
Add nixkell to the Haskell subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
 * [stack2nix](https://github.com/input-output-hk/stack2nix) - Generate nix expressions for Haskell projects.
 * [nix-haskell-mode](https://github.com/matthewbauer/nix-haskell-mode) - Automatic Haskell setup in Emacs.
 * [haskell.nix](https://github.com/input-output-hk/haskell.nix) - Alternative Haskell Infrastructure for Nixpkgs.
+* [nixkell](https://github.com/pwm/nixkell) - Get your Haskell projects up and running with no fuss using Nix.
 
 ### Node.js
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@
 * [stack2nix](https://github.com/input-output-hk/stack2nix) - Generate nix expressions for Haskell projects.
 * [nix-haskell-mode](https://github.com/matthewbauer/nix-haskell-mode) - Automatic Haskell setup in Emacs.
 * [haskell.nix](https://github.com/input-output-hk/haskell.nix) - Alternative Haskell Infrastructure for Nixpkgs.
-* [nixkell](https://github.com/pwm/nixkell) - Get your Haskell projects up and running with no fuss using Nix.
+* [nixkell](https://github.com/pwm/nixkell) - A Haskell project template using Nix and direnv.
 
 ### Node.js
 


### PR DESCRIPTION
Add [nixkell](https://github.com/pwm/nixkell) to the Haskell subsection of Programming Languages.