### PR TITLE
Replace deprecated unofficial Matrix channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@
 
 ## Community
 
-* [#nix:matrix.org (Unofficial)](https://matrix.to/#/#nix:matrix.org)
+* [#nix:nixos.org](https://matrix.to/#/#nix:nixos.org)
 * [#nixos on FreeNode](https://webchat.freenode.net/?channels=nixos)
 * [Discord - Nix/Nixos (Unofficial)](https://discord.gg/BMUCQx6)
 * [Discourse](https://discourse.nixos.org/) - The best place to get help and discuss Nix-related topics.


### PR DESCRIPTION
With the controversy over FreeNode, the NixOS group both moved to libera.chat and formalized their presence on Matrix with Matrix Spaces.

This commit changes the Matrix channel from the now archived #nix:matrix.org to the official #nix:nixos.org

Part of changes to the chat system made to reflect the current state of communication.