### PR TITLE
Replace Freenode IRC channel with Libera.chat IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@
 ## Community
 
 * [#nix:matrix.org (Unofficial)](https://matrix.to/#/#nix:matrix.org)
-* [#nixos on FreeNode](https://webchat.freenode.net/?channels=nixos)
+* [#nixos on Libera.Chat](ircs://irc.libera.chat:6697/nixos/nixos)
 * [Discord - Nix/Nixos (Unofficial)](https://discord.gg/BMUCQx6)
 * [Discourse](https://discourse.nixos.org/) - The best place to get help and discuss Nix-related topics.
 * [NixCon](https://nixcon.org/) - The annual community conference for contributors and users of Nix and NixOS.


### PR DESCRIPTION
With the controversy over Freenode, the NixOS group both moved to libera.chat and formalized their presence on Matrix with Matrix Spaces.

This commit changes the IRC channel from Freenode to Libera.chat.

Part of changes to the chat system made to reflect the current state of communication.