### PR TITLE
Fix Lychee Runner - Remove NixDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@
 ### Discovery
 
 * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories.
-* [NixDB](https://4shells.com/nixdb) - A database with Nix packages at all versions, from all channels.
 
 ### Newsletters
 


### PR DESCRIPTION
NixDB looks to have been taken offline. Notably, the daily link checker
seems not to be running, so this hasn't been caught before a recent pull
request.

The project may be replaced with https://pkgs.on-nix.com/ at some point,
looking at <https://github.com/orgs/on-nix/repositories> but this website hasn't yet been implemented so...