### PR TITLE
Update NixDB to Pkgs on Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 ### Discovery
 
 * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories.
-* [NixDB](https://4shells.com/nixdb) - A database with Nix packages at all versions, from all channels.
+* [Pkgs on Nix](https://pkgs.on-nix.com/) - A database with Nix packages at all versions, from all channels.
 
 ### Newsletters
 


### PR DESCRIPTION
NixDB has been replaced with Pkgs on Nix, and is located at a different
URL. Update the link and the resource name to reflect such.

Thanks to @kamadorueda for the new location