### PR TITLE
Add statix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 * [nix-index](https://github.com/bennofs/nix-index) - Quickly locate Nix packages with specific files.
 * [nix-prefetch](https://github.com/msteen/nix-prefetch) - A universal tool for updating source checksums.
 * [nix-tree](https://github.com/utdemir/nix-tree) - Interactively browse the dependency graph of Nix derivations.
+* [statix](https://github.com/nerdypepper/statix) - A linter/fixer to check for and fix antipatterns in Nix code.
 
 ## Development
 


### PR DESCRIPTION
Add the [statix linter/fixer CLI tool](https://github.com/nerdypepper/statix) to the alphabetical list.

It's fast and looks to do its job well. Only problems are limited editor integration at the moment (which I'm trying to help fix for Vim/NeoVim).