### PR TITLE
Add robotnix

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 * [nix-direnv](https://github.com/nix-community/nix-direnv) - A fast loader and flake-compliant configuration for the direnv environment auto-loader.
 * [nixpkgs-review](https://github.com/Mic92/nixpkgs-review) - The best tool to verify that a pull-request in Nixpkgs is building properly.
 * [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix) - Run linters/formatters at commit time and on your CI.
+* [robotnix](https://github.com/danielfullmer/robotnix) - A declarative and reproducible build system for Android (AOSP) images.
 
 ## Programming Languages
 


### PR DESCRIPTION
- Added robotnix to the list
I am not sure whether Robotnix belongs under the Development section. It might be better to rename the NixOS Modules section to just Modules and then add robotnix to that?