### PR TITLE
Add base16.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@
 
 ## NixOS Modules
 
+* [base16.nix](https://github.com/SenchoPens/base16.nix) - Flake way to theme programs in [base16](https://github.com/chriskempson/base16) colorschemes, mustache template support included.
 * [musnix](https://github.com/musnix/musnix) - Do real-time audio work in NixOS.
 * [nixcloud-webservices](https://github.com/nixcloud/nixcloud-webservices) - A Nixpkgs extension with a focus on ease of deployment of web-related technologies.
 * [Simple Nixos Mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver) - A complete mailserver, managed with NixOS modules.


### PR DESCRIPTION
Hi! First of all, thank you for maintaining such useful resource.

I want to include a small module - [base16.nix](https://github.com/SenchoPens/base16.nix) - that I've written myself. I think it's API and docs are complete, I've tested it and there aren't any bugs I know of.

Few words on it's usefullness:
base16 is a widespread standard of defining colorschemes and templates to theme particular applications (defined in mustache templating language), yet NixOS lacked a module that supported usage of schemes as well as mustache templates; so I've written one, utilizing the power of flakes and Nix to make library as convinient as possible, while not limiting the user in any way.