### PR TITLE
Add Stylix

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@
 * [nixcloud-webservices](https://github.com/nixcloud/nixcloud-webservices) - A Nixpkgs extension with a focus on ease of deployment of web-related technologies.
 * [NixVim](https://github.com/pta2002/nixvim) - A NeoVim distribution built with Nix modules and Nixpkgs.
 * [Simple Nixos Mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver) - A complete mailserver, managed with NixOS modules.
+* [Stylix](https://github.com/danth/stylix) - System-wide colorscheming and typography for NixOS.
 
 ## Overlays
 


### PR DESCRIPTION
Stylix is a NixOS module which applies a standard colourscheme and font to every supported application, including:

- Everything which uses GTK: notably Firefox and the GNOME apps
- Text editors: Vim, NeoVim and Helix
- Terminals: Kitty and Foot
- The Linux console
- The Plymouth boot screen
- The GRUB bootloader

It also exports functions and values which make it easy to use the theme elsewhere within your NixOS configuration.

The colours used are generated from a background image, using a homemade [genetic algorithm](https://en.wikipedia.org/wiki/Genetic_algorithm).  
Fonts are selected by the user via a NixOS option, choosing from any of the font packages available in Nixpkgs.

Stylix builds upon [base16.nix](https://github.com/SenchoPens/base16.nix#base16nix) to manage the installation of themes into the appropriate location, as required by the application which is being themed.  
base16.nix uses templates from [Base16](http://chriskempson.com/projects/base16/).