### PR TITLE
chore: add cargo2nix/cargo2nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@
 
 ### Rust
 
+* [cargo2nix](https://github.com/cargo2nix/cargo2nix) - Granular caching, development shell, Nix & Rust integration.
 * [fenix](https://github.com/nix-community/fenix) - Rust toolchains and Rust analyzer nightly for nix.
 * [naersk](https://github.com/nmattia/naersk) - Build Rust packages directly from `Cargo.lock`. No conversion step needed.
 * [nix-cargo-integration](https://github.com/yusdacra/nix-cargo-integration) - A library that allows easy and effortless integration for Cargo projects.


### PR DESCRIPTION
I've used the project's official GitHub description as the explanation. 