### PR TITLE
CONTRIBUTING.md: Tweak grammar for readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Make sure your pull request follows these guidelines:
 - Make an individual pull request for each suggestion.
 - Use the following format: `[Resource Title](url) — description.`
 - Expand on why the resource is useful in your pull request if needed.
-- Keep descriptions short and simple, but persuasive and factual (a recommended format is an agile "user story" format of "A \[tool that does thing] with|via \[special property] so that \[benefit to user]").
+- Keep descriptions short and simple.
 - Adding new categories, or improving existing categories is welcome!
 - Double check your spelling and grammar! 😁
 - Keep entries sorted alphabetically by title.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Make sure your pull request follows these guidelines:
 - Use the following format: `[Resource Title](url) — description.`
 - Expand on why the resource is useful in your pull request if needed.
 - Keep descriptions short and simple.
-- Adding new categories, or improving existing categories is welcome!
+- Add new categories or improve existing categories if possible -- it's welcome!
 - Double check your spelling and grammar! 😁
 - Keep entries sorted alphabetically by title.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ Make sure your pull request follows these guidelines:
 - Make an individual pull request for each suggestion.
 - Use the following format: `[Resource Title](url) — description.`
 - Expand on why the resource is useful in your pull request if needed.
-- Keep descriptions short and simple, but descriptive. 
+- Keep descriptions short and simple, but persuasive and factual (a recommended format is an agile "user story" format of "A \[tool that does thing] with|via \[special property] so that \[benefit to user]").
 - Adding new categories, or improving existing categories is welcome!
 - Double check your spelling and grammar! 😁
-- Keep entries sorts alphabetically by the title.
+- Keep entries sorted alphabetically by title.
 
 Thanks for contributing!


### PR DESCRIPTION
In the past, we've allowed rather non-descript summary descriptions for
projects (see the `nixpkgs-hammering` entry). In order to better comply
with the official comment guidelines laid out in the parent `awesome`
project and better serve those browsing the list, update the
contributing guidelines to specify that descriptions should also be
persuasive and factual, while providing an example format.

Additionally, fix the grammar/verb-tense for the alphabetical
requirement.

Part of a bit of cleanup. Closes #125 