### PR TITLE
add section NixOS Configuration Editors

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -27,4 +27,6 @@ Here lie the following former awesome-list members as they have been archived, d
 ## NixOS Configuration Editors
 
 * [nix-gui](https://github.com/nix-gui/nix-gui) - Desktop app in Python and Qt. (Unmaintained)
+* [nixos-manager](https://github.com/pmiddend/nixos-manager) - Desktop app in Haskell and GTK. (Unmaintained)
+* [Nixos-Gui](https://github.com/Celestialme/Nixos-Gui) - Desktop app in JavaScript, Svelte, Tauri. (Unmaintained)
 * [nixui](https://github.com/matejc/nixui) - Desktop app in JavaScript, NodeWebkit. (Unmaintained)

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -8,6 +8,7 @@ Here lie the following former awesome-list members as they have been archived, d
     * [Haskell](#haskell)
     * [Node.js](#nodejs)
     * [Scala](#scala)
+* [NixOS Configuration Editors](#nixos-configuration-editors)
 
 ## Programming Languages
 
@@ -23,3 +24,7 @@ Here lie the following former awesome-list members as they have been archived, d
 
 * [sbt-nix.g8](https://github.com/gvolpe/sbt-nix.g8) - giter8 template for new Scala projects with Nix support. (Archived)
 
+## NixOS Configuration Editors
+
+* [nix-gui](https://github.com/nix-gui/nix-gui) - Desktop app in Python and Qt. (Unmaintained)
+* [nixui](https://github.com/matejc/nixui) - Desktop app in JavaScript, NodeWebkit. (Unmaintained)

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -26,7 +26,7 @@ Here lie the following former awesome-list members as they have been archived, d
 
 ## NixOS Configuration Editors
 
-* [nix-gui](https://github.com/nix-gui/nix-gui) - Desktop app in Python and Qt. (Unmaintained)
+* [Nix-Gui](https://github.com/nix-gui/nix-gui) - Desktop app in Python and Qt. (Unmaintained)
 * [nixos-manager](https://github.com/pmiddend/nixos-manager) - Desktop app in Haskell and GTK. (Unmaintained)
 * [Nixos-Gui](https://github.com/Celestialme/Nixos-Gui) - Desktop app in JavaScript, Svelte, Tauri. (Unmaintained)
-* [nixui](https://github.com/matejc/nixui) - Desktop app in JavaScript, NodeWebkit. (Unmaintained)
+* [NixUI](https://github.com/matejc/nixui) - Desktop app in JavaScript, NodeWebkit. (Unmaintained)

--- a/README.md
+++ b/README.md
@@ -194,10 +194,8 @@ See also [Command-Line Tools](#command-line-tools)
 
 ### Desktop apps
 
-* [nixos-manager](https://github.com/pmiddend/nixos-manager) - Desktop app in Haskell and GTK.
 * [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Desktop app in Rust and GTK.
 * [nix-software-center](https://github.com/vlinkz/nix-software-center) - Install and manage Nix packages. Desktop app in Rust and GTK.
-* [Nixos-Gui](https://github.com/Celestialme/Nixos-Gui) - Desktop app in JavaScript, Svelte, Tauri.
 
 ### Webinterface
 

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@
 
 ### Desktop apps
 
-* [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Graphical editor for NixOS configuration. Desktop app in Rust and GTK.
-* [nix-software-center](https://github.com/vlinkz/nix-software-center) - Install and manage Nix packages, both imperatively and declaratively. Desktop app in Rust and GTK.
+* [NixOS Configuration Editor](https://github.com/vlinkz/nixos-conf-editor) - Graphical editor for NixOS configuration. Desktop app in Rust and GTK.
+* [Nix Software Center](https://github.com/vlinkz/nix-software-center) - Install and manage Nix packages. Desktop app in Rust and GTK.
 
 ### Webinterface
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@
 
 ### Desktop apps
 
-* [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Desktop app in Rust and GTK.
+* [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Graphical editor for NixOS configuration. Desktop app in Rust and GTK.
 * [nix-software-center](https://github.com/vlinkz/nix-software-center) - Install and manage Nix packages. Desktop app in Rust and GTK.
 
 ### Webinterface

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
     * [Rust](#rust)
     * [Scala](#scala)
 * [NixOS Modules](#nixos-modules)
+* [NixOS Configuration Editors](#nixos-configuration-editors)
 * [Overlays](#overlays)
 * [Community](#community)
 
@@ -186,6 +187,25 @@
 * [NixVim](https://github.com/pta2002/nixvim) - A NeoVim distribution built with Nix modules and Nixpkgs.
 * [Simple Nixos Mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver) - A complete mailserver, managed with NixOS modules.
 * [Stylix](https://github.com/danth/stylix) - System-wide colorscheming and typography for NixOS.
+
+## NixOS Configuration Editors
+
+See also [Command-Line Tools](#command-line-tools)
+
+It's surprisingly hard to build a good config editor for NixOS,
+so please lower your expectations.
+
+### Desktop apps
+
+* [nix-gui](https://github.com/nix-gui/nix-gui) - Desktop app in Python and Qt. Abandoned.
+* [nixos-manager](https://github.com/pmiddend/nixos-manager) - Desktop app in Haskell and GTK.
+* [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Desktop app in Rust and GTK.
+* [Nixos-Gui](https://github.com/Celestialme/Nixos-Gui) - Desktop app in JavaScript, Svelte, Tauri.
+* [nixui](https://github.com/matejc/nixui) - Desktop app in JavaScript, NodeWebkit. Old.
+
+### Webinterface
+
+* [mynixos.com](https://mynixos.com/) - Create and share software configurations using the NixOS ecosystem.
 
 ## Overlays
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ so please lower your expectations.
 
 * [nixos-manager](https://github.com/pmiddend/nixos-manager) - Desktop app in Haskell and GTK.
 * [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Desktop app in Rust and GTK.
+* [nix-software-center](https://github.com/vlinkz/nix-software-center) - Install and manage Nix packages. Desktop app in Rust and GTK.
 * [Nixos-Gui](https://github.com/Celestialme/Nixos-Gui) - Desktop app in JavaScript, Svelte, Tauri.
 
 ### Webinterface

--- a/README.md
+++ b/README.md
@@ -190,8 +190,6 @@
 
 ## NixOS Configuration Editors
 
-See also [Command-Line Tools](#command-line-tools)
-
 ### Desktop apps
 
 * [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Desktop app in Rust and GTK.

--- a/README.md
+++ b/README.md
@@ -197,11 +197,9 @@ so please lower your expectations.
 
 ### Desktop apps
 
-* [nix-gui](https://github.com/nix-gui/nix-gui) - Desktop app in Python and Qt. Abandoned.
 * [nixos-manager](https://github.com/pmiddend/nixos-manager) - Desktop app in Haskell and GTK.
 * [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Desktop app in Rust and GTK.
 * [Nixos-Gui](https://github.com/Celestialme/Nixos-Gui) - Desktop app in JavaScript, Svelte, Tauri.
-* [nixui](https://github.com/matejc/nixui) - Desktop app in JavaScript, NodeWebkit. Old.
 
 ### Webinterface
 

--- a/README.md
+++ b/README.md
@@ -192,9 +192,6 @@
 
 See also [Command-Line Tools](#command-line-tools)
 
-It's surprisingly hard to build a good config editor for NixOS,
-so please lower your expectations.
-
 ### Desktop apps
 
 * [nixos-manager](https://github.com/pmiddend/nixos-manager) - Desktop app in Haskell and GTK.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@
 
 ### Webinterface
 
-* [mynixos.com](https://mynixos.com/) - Create and share software configurations using the NixOS ecosystem.
+* [mynixos.com](https://mynixos.com/) - Graphical editor for Nix flakes. Create and manage configurations and modules for NixOS and Nix home-manager. Rather a Nix generator than a Nix editor, because it does not allow to import Nix files.
 
 ## Overlays
 

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@
 ### Desktop apps
 
 * [nixos-conf-editor](https://github.com/vlinkz/nixos-conf-editor) - Graphical editor for NixOS configuration. Desktop app in Rust and GTK.
-* [nix-software-center](https://github.com/vlinkz/nix-software-center) - Install and manage Nix packages. Desktop app in Rust and GTK.
+* [nix-software-center](https://github.com/vlinkz/nix-software-center) - Install and manage Nix packages, both imperatively and declaratively. Desktop app in Rust and GTK.
 
 ### Webinterface
 
-* [mynixos.com](https://mynixos.com/) - Graphical editor for Nix flakes. Create and manage configurations and modules for NixOS and Nix home-manager. Rather a Nix generator than a Nix editor, because it does not allow to import Nix files.
+* [MyNixOS](https://mynixos.com/) - Graphical editor for Nix flakes. Create and manage configurations and modules for NixOS and Nix home-manager. Rather a Nix generator than a Nix editor, because it does not allow to import Nix files.
 
 ## Overlays
 


### PR DESCRIPTION
this is an import of my nixos wiki article [NixOS configuration editors](https://nixos.wiki/wiki/NixOS_configuration_editors)

why?

im working on a config editor with webinterface
see [nixos-config-webui](https://github.com/milahu/nixos-config-webui)

the main problem with all these config editors is:
we have no **incremental** evaluator for nix

so you cannot really build a hybrid editor
which is both pretty and powerful

thats also why we still have no proper intellisense for nix files
see also https://github.com/nix-community/rnix-lsp/issues/41

> we have no **incremental** evaluator

so currently im working on that in my [nix-eval-js](https://github.com/milahu/nix-eval-js)
