### PR TITLE
Add `bento` to the list of Deployment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 
 ## Deployment Tools
 
+* [bento](https://github.com/rapenne-s/bento/) - A KISS deployment tool to keep your NixOS fleet (servers & workstations) up to date.
 * [Colmena](https://github.com/zhaofengli/colmena) - A simple, stateless NixOS deployment tool modeled after NixOps and morph.
 * [deploy-rs](https://github.com/serokell/deploy-rs) - A simple multi-profile Nix-flake deploy tool.
 * [krops](https://cgit.krebsco.de/krops/about/) - A lightweight toolkit to deploy NixOS systems, remotely or locally.


### PR DESCRIPTION
Adds [bento](https://github.com/rapenne-s/bento/) - yet another tool to deploy your nix systems.

cc @rapenne-s