### PR TITLE
Move pypi2nix to `DEPRECATED.md`

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -7,6 +7,7 @@ Here lie the following former awesome-list members as they have been archived, d
 * [Programming Languages](#programming-languages)
     * [Haskell](#haskell)
     * [Node.js](#nodejs)
+    * [Python](#python)
     * [Scala](#scala)
 * [NixOS Configuration Editors](#nixos-configuration-editors)
 
@@ -19,6 +20,10 @@ Here lie the following former awesome-list members as they have been archived, d
 ### Node.js
 
 * [yarn2nix](https://github.com/nix-community/yarn2nix) - Generate Nix expressions from a `yarn.lock` file. (Archived)
+
+### Python
+
+* [pypi2nix](https://github.com/nix-community/pypi2nix) - Generate Nix expressions for Python packages.
 
 ### Scala
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@
 
 * [mach-nix](https://github.com/DavHau/mach-nix) - Tool to create highly reproducible python environments.
 * [poetry2nix](https://github.com/nix-community/poetry2nix) - Build Python packages directly from [Poetry's](https://python-poetry.org/) `poetry.lock`. No conversion step needed.
-* [pypi2nix](https://github.com/nix-community/pypi2nix) - Generate Nix expressions for Python packages.
 
 ### Ruby
 


### PR DESCRIPTION
pypi2nix has been archived, so move it to `DEPRECATED.md` as part of addressing #163