### PR TITLE
Deprecate NixOS weekly

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -4,12 +4,20 @@ Here lie the following former awesome-list members as they have been archived, d
 
 ## Contents
 
+* [Resources](#resources)
+    * [Newsletters](#newsletters)
 * [Programming Languages](#programming-languages)
     * [Haskell](#haskell)
     * [Node.js](#nodejs)
     * [Python](#python)
     * [Scala](#scala)
 * [NixOS Configuration Editors](#nixos-configuration-editors)
+
+## Resources
+
+### Newsletters
+
+* [NixOS Weekly](https://weekly.nixos.org/) - *The* newsletter to stay informed about community updates. (Last update was made in 2021)
 
 ## Programming Languages
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 * [Resources](#resources)
     * [Learning](#learning)
     * [Discovery](#discovery)
-    * [Newsletters](#newsletters)
 * [Installation Media](#installation-media)
 * [Channel History](#channel-history)
 * [Deployment Tools](#deployment-tools)
@@ -59,10 +58,6 @@
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [Pkgs on Nix](https://pkgs.on-nix.com/) - A database with Nix packages at all versions, from all channels.
 * [Home Manager Option Search](https://mipmip.github.io/home-manager-option-search/) - Search through all 2000+ Home Manager options and read how to use them.
-
-### Newsletters
-
-* [NixOS Weekly](https://weekly.nixos.org/) - *The* newsletter to stay informed about community updates.
 
 ## Installation Media
 


### PR DESCRIPTION
The newsletter was last updated in 2021, so I figure we can mark it as unmaintained by now
