### PR TITLE
Add chaotic-nyx

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@
 ## Overlays
 
 * [awesome-nix-hpc](https://github.com/freuk/awesome-nix-hpc) - High Performance Computing package sets.
+* [chaotic-nyx](https://github.com/chaotic-cx/nyx) - Daily bumped bleeding edge packages like `mesa_git` & others that aren't yet in Nixpkgs. Created by the makers of [Chaotic-AUR](https://github.com/chaotic-aur/). 
 * [nix-darwin](https://github.com/LnL7/nix-darwin) - Manage macOS configuration just like on NixOS.
 * [nixpkgs-firefox-darwin](https://github.com/bandithedoge/nixpkgs-firefox-darwin) - Automatically updated Firefox binary packages for macOS.
 * [nixpkgs-wayland](https://github.com/nix-community/nixpkgs-wayland) - Bleeding-edge Wayland packages.


### PR DESCRIPTION
Adds the Chaotic's Nyx overlay. 
A list of packages can be found [here](https://github.com/chaotic-cx/nyx#list-of-packages), a few [options](https://github.com/chaotic-cx/nyx#list-of-options) are provided as well.