### PR TITLE
Update flakelight url to nix-community/flakelight

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@
 * [flake.parts](https://github.com/hercules-ci/flake-parts) - Minimal Nix modules framework for Flakes: split your flakes into modules and get things done with community modules.
 * [flake-utils](https://github.com/numtide/flake-utils) - Pure Nix flake utility functions to help with writing flakes.
 * [flake-utils-plus](https://github.com/gytis-ivaskevicius/flake-utils-plus) - A lightweight Nix library flake for painless NixOS flake configuration.
-* [flakelight](https://github.com/accelbread/flakelight) - A modular flake framework aiming to minimize boilerplate.
+* [flakelight](https://github.com/nix-community/flakelight) - A modular flake framework aiming to minimize boilerplate.
 * [flox](https://github.com/flox/flox) - Manage and share development environments, package projects, and publish artifacts anywhere.
 * [gitignore.nix](https://github.com/hercules-ci/gitignore.nix) - The most feature-complete and easy-to-use `.gitignore` integration.
 * [haumea](https://github.com/nix-community/haumea) - Filesystem-based module system for the Nix language similar to traditional programming languages, with support for file hierarchy and visibility.


### PR DESCRIPTION
Flakelight has been moved to https://github.com/nix-community/flakelight