### PR TITLE
README.md: NixCon https -> http

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,5 +270,5 @@
 * [#nixos on Libera.Chat](https://web.libera.chat/?nick=Guest?#nixos)
 * [Discord - Nix/Nixos (Unofficial)](https://discord.gg/BMUCQx6)
 * [Discourse](https://discourse.nixos.org/) - The best place to get help and discuss Nix-related topics.
-* [NixCon](https://nixcon.org/) - The annual community conference for contributors and users of Nix and NixOS.
+* [NixCon](http://nixcon.org/) - The annual community conference for contributors and users of Nix and NixOS.
 * [Wiki (Unofficial)](https://nixos.wiki)


### PR DESCRIPTION
The certificate looks to have expired or something, so the https redirect for NixCon's site is broken. This should work as a stopgap until <https://github.com/nixcon/nixcon.org/issues/2> is fixed.