### PR TITLE
README.md: Re-add nix-output-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@
 * [nix-index](https://github.com/bennofs/nix-index) - Quickly locate Nix packages with specific files.
 * [nix-init](https://github.com/nix-community/nix-init) - Generate Nix packages from URLs with hash prefetching, dependency inference, license detection, and more.
 * [nix-melt](https://github.com/nix-community/nix-melt) - A ranger-like flake.lock viewer.
-<!-- * [nix-output-monitor](https://git.maralorn.de/nix-output-monitor/) - A tool to produce useful graphs and statistics when building derivations. -->
+* [nix-output-monitor](https://github.com/maralorn/nix-output-monitor) - A tool to produce useful graphs and statistics when building derivations.
 * [nix-prefetch](https://github.com/msteen/nix-prefetch) - A universal tool for updating source checksums.
 * [nix-tree](https://github.com/utdemir/nix-tree) - Interactively browse the dependency graph of Nix derivations.
 * [nurl](https://github.com/nix-community/nurl) - Generate Nix fetcher calls from repository URLs.


### PR DESCRIPTION
Add back `nix-output-monitor` with the canonical GitHub source. Thanks to @Mic92