### PR TITLE
Add Searchix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 * [Nix Package Versions](https://lazamar.co.uk/nix-versions/) - Find all versions of a package that were available in a channel and the revision you can download it from.
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [Home Manager Option Search](https://mipmip.github.io/home-manager-option-search/) - Search through all 2000+ Home Manager options and read how to use them.
+* [Searchix](https://searchix.alanpearce.eu/) - Search Nix packages and options from NixOS, Darwin and Home Manager.
 
 ## Installation Media
 


### PR DESCRIPTION
Searchix is a web-based search engine for Nix packages and options from NixOS, nix-darwin and home-manager. I am its initial author.

Regarding the 30-day rule: although I only [announced it on the forum](https://discourse.nixos.org/t/searchix-web-based-option-package-search-including-nix-darwin-and-home-manager/48877) on 2024-07-11, it's been around a while longer ([release history](https://git.sr.ht/~alanpearce/searchix/refs)).