### PR TITLE
Add nix-gleam

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@
 
 ### Gleam
 
-* [nix-gleam](https://github.com/arnarg/nix-gleam) - Generic nix builder for gleam applications.
+* [nix-gleam](https://github.com/arnarg/nix-gleam) - Generic Nix builder for Gleam applications.
 
 ### Haskell
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     * [Clojure](#clojure)
     * [Crystal](#crystal)
     * [Elm](#elm)
+    * [Gleam](#gleam)
     * [Haskell](#haskell)
     * [Haxe](#haxe)
     * [Node.js](#nodejs)
@@ -183,6 +184,10 @@
 ### Elm
 
 * [elm2nix](https://github.com/cachix/elm2nix) - Convert `elm.json` into Nix expressions.
+
+### Gleam
+
+* [nix-gleam](https://github.com/arnarg/nix-gleam) - Generic nix builder for gleam applications.
 
 ### Haskell
 


### PR DESCRIPTION
nix-gleam is a generic builder for gleam applications. Supports both erlang and javascript target.