### PR TITLE
nixpkgs-fmt is now nixfmt

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -20,6 +20,10 @@ Here lie the following former awesome-list members as they have been archived, d
 
 * [NixOS Weekly](https://weekly.nixos.org/) - *The* newsletter to stay informed about community updates. (Last update was made in 2021)
 
+## Command-Line Tools
+
+* [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt) formatter is now [nixfmt](https://github.com/NixOS/nixfmt).
+
 ## Programming Languages
 
 ### Haskell

--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@
 * [devenv](https://github.com/cachix/devenv) - A Nix-based tool for creating developer shell environments quickly and reproducibly.
 * [manix](https://github.com/mlvzk/manix) - Find configuration options and function documentation for Nixpkgs, NixOS, and Home Manager.
 * [nh](https://github.com/viperML/nh) - Better output for `nix` `nixos-rebuild` and home-manger CLI using `nvd` and `nix-output-monitor`.
-* [nixfmt](https://github.com/serokell/nixfmt) - A formatter for Nix code, intended to easily apply a uniform style.
-* [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt) - Nix code formatter for nixpkgs.
+* [nixfmt](https://github.com/NixOS/nixfmt) - A formatter for Nix code, intended to easily apply a uniform style.
 * [nixpkgs-hammering](https://github.com/jtojnar/nixpkgs-hammering) - An opinionated linter for Nixpkgs package expressions.
 * [nix-alien](https://github.com/thiagokokada/nix-alien) - Run unpatched binaries on Nix/NixOS easily.
 * [nix-diff](https://github.com/Gabriella439/nix-diff) - A tool to explain why two Nix derivations differ.


### PR DESCRIPTION
https://github.com/nix-community/nixpkgs-fmt has been archived in favor of https://github.com/NixOS/nixfmt, we can delete the mention of the former to simplify life to newcomers.