### PR TITLE
add nix-search-tv

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 
 <!-- * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories. -->
 * [Nix Package Versions](https://lazamar.co.uk/nix-versions/) - Find all versions of a package that were available in a channel and the revision you can download it from.
-* [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - Nix packages CLI fuzzy finder
+* [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - CLI fuzzy finder for packages and options from Nixpkgs, Home Manager, and more.
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [Home Manager Option Search](https://mipmip.github.io/home-manager-option-search/) - Search through all 2000+ Home Manager options and read how to use them.
 * [NüschtOS Search](https://github.com/NuschtOS/search) - Simple and fast static-page NixOS option search.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 
 <!-- * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories. -->
 * [Nix Package Versions](https://lazamar.co.uk/nix-versions/) - Find all versions of a package that were available in a channel and the revision you can download it from.
+* [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - Nix packages CLI fuzzy finder
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [Home Manager Option Search](https://mipmip.github.io/home-manager-option-search/) - Search through all 2000+ Home Manager options and read how to use them.
 * [NüschtOS Search](https://github.com/NuschtOS/search) - Simple and fast static-page NixOS option search.


### PR DESCRIPTION
Hi there,

Firstly, thank you the maintainer of that project for the work. I use it myself, and it's helped me a few times.

I'd like to add a tool that I've made. As the description says, it's a CLI nix packages finder. I put it into the Discovery category, because it's functionally close to other tools in the same category. However, there is also the Command-Line category, which also matches, but rather by the form, than the purpose.

Please let me know what you think fits better, and I'll update the PR accordingly