### PR TITLE
README.md: Fix logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# Awesome Nix [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [<img src="https://nixos.org/logo/nixos-logo-only-hires.png" width="200" align="right" alt="NixOS">](https://nixos.org)
+# Awesome Nix [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+<a href="https://nixos.org">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png">
+    <img src="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos.svg" align="right" width="250" alt="NixOS logo">
+  </picture>
+</a>
 
 > A curated list of the best resources in the Nix community.
+
+<br>
 
 [Nix](https://github.com/nixos/nix) is a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible.
 


### PR DESCRIPTION
Apparently the NixOS org changed around where the logo is. I copied the implementation from <https://github.com/nixos/nix> and added a line break to get it fitting a bit better.

I used <https://github.com/sindresorhus/awesome-electron/blob/main/readme.md> as a reference for the image location, as proposed in the [List Guidelines](https://github.com/sindresorhus/awesome/blob/main/pull_request_template.md).

As I understand this should fix both action runs and the README.md formatting