### PR TITLE
Add NixOS hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@
 * [nix-mineral](https://github.com/cynicsketch/nix-mineral) - Conveniently and reasonably harden NixOS.
 * [nix-topology](https://github.com/oddlama/nix-topology) - Generate infrastructure and network diagrams directly from your NixOS configuration.
 * [impermanence](https://github.com/nix-community/impermanence) - Lets you choose what files and directories you want to keep between reboots.
+* [NixOS hardware](https://github.com/NixOS/nixos-hardware) - NixOS profiles to optimize settings for different hardware.
 
 ## NixOS Configuration Editors
 


### PR DESCRIPTION
I find it a bit odd this isn't already on the list. Is there a reason for that? Anyways, here's a PR to add it - if you'd want to :)

Also, the entries under NixOS modules aren't in alphabetical order, and so therefore I placed NixOS hardware at the bottom. Maybe we should sort them all? Looking closer at it, some other sections don't seem to be alphabetically sorted either. I'll open an issue about it: #292