### PR TITLE
.github/workflows/check-link.yml: Grant `issues:write` permissions

### DIFF
--- a/.github/workflows/check-link.yml
+++ b/.github/workflows/check-link.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Restore lychee cache
         id: cache-load


### PR DESCRIPTION
Add token permissions of `issues: write` so the issue update step doesn't fail due to insufficient permissions.

See also: https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment