### PR TITLE
Add uv2nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@
 ### Python
 
 * [poetry2nix](https://github.com/nix-community/poetry2nix) - Build Python packages directly from [Poetry's](https://python-poetry.org/) `poetry.lock`. No conversion step needed.
+* [uv2nix](https://github.com/pyproject-nix/uv2nix) - Convert [`uv` workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/) into pure Nix derivations.
 
 ### Ruby
 


### PR DESCRIPTION
Add [`uv2nix`](https://github.com/pyproject-nix/uv2nix), a framework to deploy `uv` workspace projects using Nix. It is based upon [`pyproject.nix`](https://github.com/pyproject-nix/pyproject.nix) which should maybe also be added to the list.