### PR TITLE
Fix awesome-lint in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,6 @@ jobs:
           fetch-depth: 0 # Needed for repository age check
 
       - name: Run awesome-lint
-        run: nix run github:NixOS/nixpkgs/nixos-unstable#nodePackages.awesome-lint
+        run: nix run github:NixOS/nixpkgs/nixos-25.05#nodePackages.awesome-lint
         env:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The usage of awesome-lint in `.github/workflows/main.yml` doesn't pin Nixpkgs to a specific commit, so it got broken by NixOS/nixpkgs#462749. This PR fixes it by switching from `nixos-unstable` to `nixos-25.05`.