### PR TITLE
Add Tofunix

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 * [pushnix](https://github.com/arnarg/pushnix) - Simple cli utility that pushes NixOS configuration and triggers a rebuild using ssh.
 * [terraform-nixos](https://github.com/nix-community/terraform-nixos) - A set of Terraform modules designed to deploy NixOS.
 * [terranix](https://terranix.org) - Use Nix and the NixOS module system to write your Terraform code.
+* [Tofunix](https://gitlab.com/TECHNOFAB/tofunix) - Combining Nix and Terraform for reproducibility and developer experience.
 
 ## Virtualisation
 


### PR DESCRIPTION
Nix-wrapper for Terraform/Opentofu, with automatic Nix options generator for providers and integration with GitLabs terraform/opentofu script/wrapper (and thus with Nix-GitLab-CI).