### PR TITLE
Add NixMkDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@
 * [nix-health](https://github.com/juspay/nix-health) - A program to check the health of your Nix install. Furthermore, individual projects can configure their own health checks in their `flake.nix`.
 * [nix-update](https://github.com/Mic92/nix-update) - Update versions/source hashes of nix packages.
 * [nixd](https://github.com/nix-community/nixd) - Nix language server, based on Nix libraries.
+* [NixMkDocs](https://gitlab.com/TECHNOFAB/nixmkdocs) - Nix library for easy mkdocs integration into projects.
 * [nixpkgs-review](https://github.com/Mic92/nixpkgs-review) - The best tool to verify that a pull-request in Nixpkgs is building properly.
 * [Nixtest](https://gitlab.com/TECHNOFAB/nixtest) - Testing framework for Nix, with snapshot and unit test support, JUnit generation etc.
 * [npins](https://github.com/andir/npins) - A simple tool for handling different types of dependencies in a Nix project. It is inspired by and comparable to Niv.


### PR DESCRIPTION
For easy mkdocs integration into projects, allows defining the mkdocs config with Nix, includes some modules for easy management of some mkdocs plugins (like mkdocs-material) and supports watching the files with live reload (except for the config sadly :D) 