### PR TITLE
Remove blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </picture>
 </a>
 
-> A curated list of the best resources in the Nix community.
+A curated list of the best resources in the Nix community.
 
 <br>
 


### PR DESCRIPTION
`>` denotes a `<blockquote>` in Markdown and is rendered as such.

> The blockquote element represents a section that is quoted from another source.

— W3C HTML spec, https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element

This block was not not quoting a source. I’m not sure if this was just an oversight.