### PR TITLE
Add Nix Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@
 <!-- * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories. -->
 * [Nix Package Versions](https://lazamar.co.uk/nix-versions/) - Find all versions of a package that were available in a channel and the revision you can download it from.
 * [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - CLI fuzzy finder for packages and options from Nixpkgs, Home Manager, and more.
+* [Nix Software](https://nixsoftware.voxelworld.ru/) - Friendly package search. Supports logos, screenshots, categories, and translations into multiple languages.
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [NüschtOS Search](https://github.com/NuschtOS/search) - Simple and fast static-page NixOS option search.
 * [Searchix](https://searchix.ovh/) - Search Nix packages and options from NixOS, Darwin and Home Manager.
-* [Nix Software](https://nixsoftware.voxelworld.ru/) - Friendly package search. Supports logos, screenshots, categories, and translations into multiple languages.
 
 ## Installation Media
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 <!-- * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories. -->
 * [Nix Package Versions](https://lazamar.co.uk/nix-versions/) - Find all versions of a package that were available in a channel and the revision you can download it from.
 * [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - CLI fuzzy finder for packages and options from Nixpkgs, Home Manager, and more.
-* [Nix Software](https://nixsoftware.voxelworld.ru/en/) - Friendly package search. Supports logos, screenshots, categories, and translations into multiple languages.
+* [Nix Software](https://nixsoftware.org/en/) - Friendly package search. Supports logos, screenshots, categories, and translations into multiple languages.
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [NüschtOS Search](https://github.com/NuschtOS/search) - Simple and fast static-page NixOS option search.
 * [Searchix](https://searchix.ovh/) - Search Nix packages and options from NixOS, Darwin and Home Manager.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 <!-- * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories. -->
 * [Nix Package Versions](https://lazamar.co.uk/nix-versions/) - Find all versions of a package that were available in a channel and the revision you can download it from.
 * [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - CLI fuzzy finder for packages and options from Nixpkgs, Home Manager, and more.
-* [Nix Software](https://nixsoftware.voxelworld.ru/) - Friendly package search. Supports logos, screenshots, categories, and translations into multiple languages.
+* [Nix Software](https://nixsoftware.voxelworld.ru/en/) - Friendly package search. Supports logos, screenshots, categories, and translations into multiple languages.
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [NüschtOS Search](https://github.com/NuschtOS/search) - Simple and fast static-page NixOS option search.
 * [Searchix](https://searchix.ovh/) - Search Nix packages and options from NixOS, Darwin and Home Manager.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [NüschtOS Search](https://github.com/NuschtOS/search) - Simple and fast static-page NixOS option search.
 * [Searchix](https://searchix.ovh/) - Search Nix packages and options from NixOS, Darwin and Home Manager.
+* [Nix Software](https://nixsoftware.voxelworld.ru/) - Friendly package search. Supports logos, screenshots, categories, and translations into multiple languages.
 
 ## Installation Media
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@
 * [Home Manager Option Search](https://mipmip.github.io/home-manager-option-search/) - Search through all 2000+ Home Manager options and read how to use them.
 <!-- * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories. -->
 * [Nix Package Versions](https://lazamar.co.uk/nix-versions/) - Find all versions of a package that were available in a channel and the revision you can download it from.
-* [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - CLI fuzzy finder for packages and options from Nixpkgs, Home Manager, and more.
 * [Nix Software](https://nixsoftware.org/en/) - Friendly package search. Supports logos, screenshots, categories, and translations into multiple languages.
+* [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - CLI fuzzy finder for packages and options from Nixpkgs, Home Manager, and more.
 * [Noogle](https://noogle.dev/) - Nix API search engine allowing to search functions based on their types and other attributes.
 * [NüschtOS Search](https://github.com/NuschtOS/search) - Simple and fast static-page NixOS option search.
 * [Searchix](https://searchix.ovh/) - Search Nix packages and options from NixOS, Darwin and Home Manager.


### PR DESCRIPTION
The [site](http://nixsoftware.org) is designed to make package discovery as simple and intuitive as possible, even if you don’t know exactly what you’re looking for and don’t speak English.

Source: [backend](https://codeberg.org/Zellrus/nix-software-backend), [frontend](https://codeberg.org/Zellrus/nix-software-frontend)