### PR TITLE
README.md: Update link for Home Manager Option Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 
 ### Discovery
 
-* [Home Manager Option Search](https://mipmip.github.io/home-manager-option-search/) - Search through all 2000+ Home Manager options and read how to use them.
+* [Home Manager Option Search](https://home-manager-options.extranix.com/) - Search through all 2000+ Home Manager options and read how to use them.
 <!-- * [Hound](https://search.nix.gsc.io) - Handily search across all or selected Nix-related repositories. -->
 * [Nix Package Versions](https://lazamar.co.uk/nix-versions/) - Find all versions of a package that were available in a channel and the revision you can download it from.
 * [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) - CLI fuzzy finder for packages and options from Nixpkgs, Home Manager, and more.


### PR DESCRIPTION
The old home-manager option search on `github.io` has been moved to <htps://home-manager-options.extranix.com/>, based on the project page.