### PR TITLE
flake-edit: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ A curated list of the best resources in the Nix community.
 * [Devbox](https://github.com/jetify-com/devbox) - Instant, portable, and predictable development environments.
 * [devshell](https://github.com/numtide/devshell) - `mkShell` with extra bits and a toml config option to be able to onboard non-nix users.
 * [dream2nix](https://github.com/nix-community/dream2nix) - A framework for automatically converting packages from other build systems to Nix.
+* [flake-edit](https://github.com/a-kenji/flake-edit) - Edit your flake inputs with auto-follows and update functionality directly from the CLI.
 * [flake-utils-plus](https://github.com/gytis-ivaskevicius/flake-utils-plus) - A lightweight Nix library flake for painless NixOS flake configuration.
 * [flake-utils](https://github.com/numtide/flake-utils) - Pure Nix flake utility functions to help with writing flakes.
 * [flake.parts](https://github.com/hercules-ci/flake-parts) - Minimal Nix modules framework for Flakes: split your flakes into modules and get things done with community modules.


### PR DESCRIPTION
Adds the flake-edit tool: https://github.com/a-kenji/flake-edit.
A CLI helping with programmatically managing your flake inputs.

Supports adding, updating, removing, deduplication through auto-follows.



![follow_input](https://github.com/user-attachments/assets/faa58424-9b3e-43dc-b863-64d890cca763)
![follow_transitive](https://github.com/user-attachments/assets/5a0ffa80-73db-4962-be32-afcebe209c55)
