### PR TITLE
Add NixoScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ A curated list of the best resources in the Nix community.
 * [nix-darwin](https://github.com/nix-darwin/nix-darwin) - Manage macOS configuration just like on NixOS.
 * [nix-mineral](https://github.com/cynicsketch/nix-mineral) - Conveniently and reasonably harden NixOS.
 * [nix-topology](https://github.com/oddlama/nix-topology) - Generate infrastructure and network diagrams directly from your NixOS configuration.
+* [NixoScope](https://github.com/giomf/nixoscope) - Visualize dependencies between NixOS modules. 
 * [NixOS hardware](https://github.com/NixOS/nixos-hardware) - NixOS profiles to optimize settings for different hardware.
 * [NixOS-WSL](https://github.com/nix-community/NixOS-WSL) - Modules for running NixOS on the Windows Subsystem for Linux.
 * [NixVim](https://github.com/nix-community/nixvim) - A Neovim distribution built with Nix modules and Nixpkgs.


### PR DESCRIPTION
Adds [NixoScope](https://github.com/giomf/NixoScope) which lets you visualize dependencies between NixOS modules.

I am the maintainer and plan to maintain it in the long run.