### PR TITLE
Add osModa to Distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ A curated list of the best resources in the Nix community.
 
 * [nixbsd](https://github.com/nixos-bsd/nixbsd) - A NixOS fork with a FreeBSD kernel.
 * [NixNG](https://github.com/nix-community/NixNG) - A GNU/Linux distribution similar to NixOS, defining difference is a focus on containers and lightweightness.
+* [osModa](https://github.com/bolivian-peru/os-moda) - A NixOS distribution where an AI agent has root access through 91 typed MCP tools, with a hash-chained audit ledger and atomic SafeSwitch deploys (Apache 2.0).
 * [SnowflakeOS](https://snowflakeos.org/) - A NixOS-based Linux distribution focused on beginner friendliness and ease of use.
 
 ## Community


### PR DESCRIPTION
Adds [osModa](https://github.com/bolivian-peru/os-moda) to the **Distributions** section, alphabetically between `NixNG` and `SnowflakeOS`.

osModa is a NixOS distribution where an AI agent has root access through 91 typed MCP tools (system, processes, services, NixOS config, hash-chained audit ledger, atomic SafeSwitch deploys, P2P encrypted mesh, crypto wallets, local STT/TTS). 80★, Apache-2.0, actively maintained.

Live deployment + ERC-8004 / A2A agent card at [spawn.os.moda](https://spawn.os.moda).

- License: Apache-2.0
- NixOS module: [nix/modules/osmoda.nix](https://github.com/bolivian-peru/os-moda/blob/main/nix/modules/osmoda.nix)
- Architecture: [docs/ARCHITECTURE.md](https://github.com/bolivian-peru/os-moda/blob/main/docs/ARCHITECTURE.md)
- Security model: [docs/SECURITY.md](https://github.com/bolivian-peru/os-moda/blob/main/docs/SECURITY.md)