### PR TITLE
Add nix-update-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A curated list of the best resources in the Nix community.
 * [nix-output-monitor](https://github.com/maralorn/nix-output-monitor) - A tool to produce useful graphs and statistics when building derivations.
 * [nix-prefetch](https://github.com/msteen/nix-prefetch) - A universal tool for updating source checksums.
 * [nix-tree](https://github.com/utdemir/nix-tree) - Interactively browse the dependency graph of Nix derivations.
+* [nix-update-git](https://github.com/yuxqiu/nix-update-git) - Update git references (tags, refs, hashes) in Nix flake files and Nix expressions.
 * [nixfmt](https://github.com/NixOS/nixfmt) - A formatter for Nix code, intended to easily apply a uniform style.
 * [nixos-cli](https://github.com/nix-community/nixos-cli) - Configurable all-in-one CLI for common NixOS tools with an emphasis on improved user experience.
 * [nixpkgs-hammering](https://github.com/jtojnar/nixpkgs-hammering) - An opinionated linter for Nixpkgs package expressions.


### PR DESCRIPTION
*nix-update-git* automatically detects and updates outdated git references in Nix files:

- Flake inputs (`ref` values and inline `?ref=` in URLs)
- Fetcher calls: `fetchgit`, `fetchFromGitHub`, `fetchFromGitLab`, `fetchFromGitea`, `fetchFromForgejo`, `fetchFromCodeberg`, `fetchFromSourcehut`, `fetchFromBitbucket`, `fetchFromGitiles`, `fetchFromRepoOrCz`, `fetchTarball`, `fetchpatch`, and `builtins.fetchGit`
- `stdenv.mkDerivation` with fetchers
- Derivation rules for language-specific builders (`buildRustPackage`, `buildGoModule`, etc.)
- Branch following with `# follow:branch <branch>` comments
- Version following with `# follow:semver <version>` and `follow:regex <regex>` comments 
- Pinning with `# pin` comments
- Modes: check (default), --update, --update --interactive
- JSON output for scripting

I am the maintainer and I've been using it regularly on my own flakes.