### PR TITLE
CONTRIBUTING.md: Require author != resource creator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Make sure your pull request follows these guidelines:
 
 - Search through the previous pull requests before making a new one! 🙏
-- Make sure you've personally used or benefited from the suggested resource.
+- Make sure you've personally used or benefited from the suggested resource, and you aren't the creator or maintainer of the resource. 👷
 - Make an individual pull request for each suggestion.
 - Use the following format: `[Resource Title](url) — description.`
 - Expand on why the resource is useful in your pull request if needed.


### PR DESCRIPTION
Require the author of the pull request to not be the creator or primary maintainer of the proposed resource, to reduce the likelihood of author conflict-of-interest.

Also added a construction-worker emoji since I felt whimsical today.

See also #334

I'm not saying a resource submitted by resource creator can't be awesome, but it's harder to judge if it is if the author of the PR stands to potentially directly benefit in opening it.

This comes after a lot of self-promotion of resources, and sort of acts as a two-person control.

It isn't retro-active, but self-promotion does colour the perspective of the review