### PR TITLE
feat: add agent-sandbox.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ A curated list of the best resources in the Nix community.
 
 ## Virtualisation
 
+* [agent-sandbox.nix](https://github.com/archie-judd/agent-sandbox.nix) - Declarative sandboxing for any package (e.g. AI coding agents) using bubblewrap on Linux and sandbox-exec on macOS.
 * [extra-container](https://github.com/erikarvstedt/extra-container) - Run declarative NixOS containers from the command line.
 * [microvm](https://github.com/microvm-nix/microvm.nix) - NixOS-based MicroVMs.
 * [nixos-shell](https://github.com/Mic92/nixos-shell) - Simple headless VM configuration using Nix (similar to Vagrant).


### PR DESCRIPTION
## Add agent-sandbox.nix to Virtualisation

Adds [agent-sandbox.nix](https://github.com/archie-judd/agent-sandbox.nix) to the Virtualisation section.

It's a lightweight  Nix library for sandboxing AI coding agents (Claude Code, Copilot CLI, etc.) on both Linux and macOS using `bubblewrap` and `sandbox-exec` respectively. The agent gets read/write access to the project directory and any paths you explicitly declare; everything else - `$HOME`, SSH keys, other projects, the system keychain - is hidden behind an ephemeral tmpfs. Network access can optionally be restricted to an allowlist of domains and HTTP methods via a filtering proxy.

It slots in alongside the other dev-environment libraries already listed in this section (`devshell`, `make-shell`, `MCP-NixOS`, etc.) - you wire it into a `flake.nix` or `shell.nix` and invoke the wrapped binary from a dev shell.

### Checklist

- [x] Searched previous pull requests for duplicates.
- [x] I am the author and active maintainer; have personally used it.
- [x] Individual PR for a single suggestion.
- [x] Uses the format `[Resource Title](url) - description.` (matching the existing entries in the file).
- [x] Resource is more than 30 days old.
- [x] Description is short.
- [x] Entry is placed alphabetically (top of the Development section, before `Arion`).
- [x] Spelling and grammar checked.
