### PR TITLE
README.md: Fix grammar in NixNG description

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ A curated list of the best resources in the Nix community.
 ## Distributions
 
 * [nixbsd](https://github.com/nixos-bsd/nixbsd) - A NixOS fork with a FreeBSD kernel.
-* [NixNG](https://github.com/nix-community/NixNG) - A GNU/Linux distribution similar to NixOS, defining difference is a focus on containers and lightweightness.
+* [NixNG](https://github.com/nix-community/NixNG) - A GNU/Linux distribution similar to NixOS. The defining difference is a focus on containers and lightweightness.
 * [SnowflakeOS](https://snowflakeos.org/) - A NixOS-based Linux distribution focused on beginner friendliness and ease of use.
 
 ## Community


### PR DESCRIPTION
Fix grammatical error in NixNG description.
Add the missing article and use a period to improve readability and flow