### PR TITLE
.lycheeignore: Add nixos.org to exclusions due to rate-limiting

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,4 @@
 # Sites with far too aggressive rate limiters that will error or timeout on bot requests
 ^https?:\/\/nixos\.wiki\/
 ^https?:\/\/searchix\.ovh\/
+^https?:\/(status.)?\/nixos\.org\/


### PR DESCRIPTION
Should fix lychee check for #349 